### PR TITLE
Pawn move fix

### DIFF
--- a/internal_comps/gp_board/src/services/move-validator.js
+++ b/internal_comps/gp_board/src/services/move-validator.js
@@ -43,14 +43,15 @@ export function getValidMoves(pieceType, pieceX, pieceY, board) {
 
 function _pawnMoves(pieceX, pieceY, board) {
   let moves = [];
+  let collisionFirst = false;
   if (getCellTeam(pieceX, pieceY, board) === GAME_KEYWORDS.WHITE_TEAM) {
-    _checkPawnCollision(pieceX, pieceY - 1, pieceX, pieceY, moves, board);
-    if (pieceY === 6) {
+    collisionFirst = _checkPawnCollision(pieceX, pieceY - 1, pieceX, pieceY, moves, board);
+    if (pieceY === 6 && !collisionFirst) {
       _checkPawnCollision(pieceX, pieceY - 2, pieceX, pieceY, moves, board);
     }
   } else {
-    _checkPawnCollision(pieceX, pieceY + 1, pieceX, pieceY, moves, board);
-    if (pieceY === 1) {
+    collisionFirst = _checkPawnCollision(pieceX, pieceY + 1, pieceX, pieceY, moves, board);
+    if (pieceY === 1 && !collisionFirst) {
       _checkPawnCollision(pieceX, pieceY + 2, pieceX, pieceY, moves, board);
     }
   }


### PR DESCRIPTION
Fixed issue where pawn could move 2 forward on first turn even if a piece was in front of it.